### PR TITLE
mod/ojt Fixes fields named comment in database tables

### DIFF
--- a/mod/ojt/db/install.xml
+++ b/mod/ojt/db/install.xml
@@ -64,7 +64,6 @@
         <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="topicid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="signedoff" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="comment" TYPE="text" NOTNULL="false" SEQUENCE="false" />
         <FIELD NAME="timemodified" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="modifiedby" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
@@ -88,7 +87,7 @@
         <FIELD NAME="topicid" TYPE="int" LENGTH="11" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="topicitemid" TYPE="int" LENGTH="11" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="status" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="comment" TYPE="text" NOTNULL="false" SEQUENCE="false" />
+        <FIELD NAME="complcomment" TYPE="text" NOTNULL="false" SEQUENCE="false" />
         <FIELD NAME="timemodified" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="modifiedby" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>

--- a/mod/ojt/db/upgrade.php
+++ b/mod/ojt/db/upgrade.php
@@ -60,6 +60,30 @@ function xmldb_ojt_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2016031400, 'ojt');
     }
 
+    if($oldversion < 2017072700) {
+        $table = new xmldb_table('ojt_topic_signoff');
+        $field = new xmldb_field('comment', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null, 'timemodified');
+
+        // This field is unused, so drop it.
+        // Condtionally drop field if it exists.
+        if($dbman->field_exists($table, $field)) {
+            $dbman->drop_field($table, $field);
+        }
+
+        $table = new xmldb_table('ojt_completion');
+        $field = new xmldb_field('comment', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null, 'timemodified');
+
+        // Rename field to complcomment as comment is a reserved name.
+        // Condtionally rename field if it exists.
+        if($dbman->field_exists($table, $field)) {
+            $dbman->rename_field($table, $field, 'complcomment');
+        }
+
+
+        // ojt savepoint reached.
+        upgrade_mod_savepoint(true, 2017072700, 'ojt');
+    }
+
 
     return true;
 }

--- a/mod/ojt/evaluatesave.php
+++ b/mod/ojt/evaluatesave.php
@@ -71,9 +71,9 @@ if ($completion = $DB->get_record('ojt_completion', $params)) {
             $completion->status = $completion->status == OJT_COMPLETE ? OJT_INCOMPLETE : OJT_COMPLETE;
             break;
         case 'savecomment':
-            $completion->comment = required_param('comment', PARAM_TEXT);
+            $completion->complcomment = required_param('comment', PARAM_TEXT);
             // append a date to the comment string
-            $completion->comment .= ' - '.userdate(time(), $dateformat).'.';
+            $completion->complcomment .= ' - '.userdate(time(), $dateformat).'.';
             break;
         default:
     }
@@ -88,9 +88,9 @@ if ($completion = $DB->get_record('ojt_completion', $params)) {
             $completion->status = OJT_COMPLETE;
             break;
         case 'savecomment':
-            $completion->comment = required_param('comment', PARAM_TEXT);
+            $completion->complcomment = required_param('comment', PARAM_TEXT);
             // append a date to the comment string
-            $completion->comment .= ' - '.userdate(time(), $dateformat).'.';
+            $completion->complcomment .= ' - '.userdate(time(), $dateformat).'.';
             break;
         default:
     }

--- a/mod/ojt/locallib.php
+++ b/mod/ojt/locallib.php
@@ -33,7 +33,7 @@ function ojt_get_user_ojt($ojtid, $userid) {
     global $DB;
 
     // Get the ojt details.
-    $sql = 'SELECT '.$userid.' AS userid, b.*, CASE WHEN c.status IS NULL THEN '.OJT_INCOMPLETE.' ELSE c.status END AS status, c.comment
+    $sql = 'SELECT '.$userid.' AS userid, b.*, CASE WHEN c.status IS NULL THEN '.OJT_INCOMPLETE.' ELSE c.status END AS status, c.complcomment
         FROM {ojt} b
         LEFT JOIN {ojt_completion} c ON b.id = c.ojtid AND c.type = ? AND c.userid = ?
         WHERE b.id = ?';
@@ -51,7 +51,7 @@ function ojt_get_user_ojt($ojtid, $userid) {
     // Add items and completion info.
     list($insql, $params) = $DB->get_in_or_equal(array_keys($ojt->topics));
     $sql = "SELECT i.*, CASE WHEN c.status IS NULL THEN ".OJT_INCOMPLETE." ELSE c.status END AS status,
-            c.comment, c.timemodified, c.modifiedby,bw.witnessedby,bw.timewitnessed,".
+            c.complcomment, c.timemodified, c.modifiedby,bw.witnessedby,bw.timewitnessed,".
             get_all_user_name_fields(true, 'moduser', '', 'modifier').",".
             get_all_user_name_fields(true, 'witnessuser', '', 'itemwitness')."
         FROM {ojt_topic_item} i

--- a/mod/ojt/renderer.php
+++ b/mod/ojt/renderer.php
@@ -136,10 +136,10 @@ class mod_ojt_renderer extends plugin_renderer_base {
                     $completionicon = $item->status == OJT_COMPLETE ? 'i/completion-manual-y' : 'i/completion-manual-n';
                     $cellcontent = $this->output->pix_icon($completionicon, '', 'core',
                         array('class' => 'ojt-completion-toggle', 'ojt-item-id' => $item->id));
-                    $cellcontent .= html_writer::tag('textarea', $item->comment,
+                    $cellcontent .= html_writer::tag('textarea', $item->complcomment,
                         array('name' => 'comment-'.$item->id, 'rows' => 3,
                             'class' => 'ojt-completion-comment', 'ojt-item-id' => $item->id));
-                    $cellcontent .= html_writer::tag('div', format_text($item->comment, FORMAT_PLAIN),
+                    $cellcontent .= html_writer::tag('div', format_text($item->complcomment, FORMAT_PLAIN),
                         array('class' => 'ojt-completion-comment-print', 'ojt-item-id' => $item->id));
                 } else {
                     // Show static stuff.
@@ -152,7 +152,7 @@ class mod_ojt_renderer extends plugin_renderer_base {
                             get_string('completionstatus'.OJT_INCOMPLETE, 'ojt'));
                     }
 
-                    $cellcontent .= format_text($item->comment, FORMAT_PLAIN);
+                    $cellcontent .= format_text($item->complcomment, FORMAT_PLAIN);
                 }
                 $userobj = new stdClass();
                 $userobj = username_load_fields_from_object($userobj, $item, $prefix = 'modifier');

--- a/mod/ojt/version.php
+++ b/mod/ojt/version.php
@@ -30,7 +30,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_ojt';
-$plugin->version = 2016031403;
+$plugin->version = 2017072700;
 $plugin->release = 'v1.0';
 $plugin->requires = 2013111800;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This is a reserved word in oracle's db so fails moodle tests, the
comment field in ojt topic signoff appeared unused, so I've removed it,
meanwhile the completion comment field was renamed to complcomment and
updated everywhere in the code it was referenced.