### PR TITLE
Update backup steps to account for new column name

### DIFF
--- a/mod/ojt/backup/moodle2/backup_ojt_stepslib.php
+++ b/mod/ojt/backup/moodle2/backup_ojt_stepslib.php
@@ -48,11 +48,11 @@ class backup_ojt_activity_structure_step extends backup_activity_structure_step 
 
         $completions = new backup_nested_element('completions');
         $completion = new backup_nested_element('completion', array('id'), array(
-            'userid', 'type', 'topicid', 'topicitemid', 'status', 'comment', 'timemodified', 'modifiedby'));
+            'userid', 'type', 'topicid', 'topicitemid', 'status', 'complcomment', 'timemodified', 'modifiedby'));
 
         $topic_signoffs = new backup_nested_element('topic_signoffs');
         $topic_signoff = new backup_nested_element('topic_signoff', array('id'), array(
-            'userid', 'topicid', 'signedoff', 'comment', 'timemodified', 'modifiedby'));
+            'userid', 'topicid', 'signedoff', 'timemodified', 'modifiedby'));
 
         $item_witnesses = new backup_nested_element('item_witnesses');
         $item_witness = new backup_nested_element('item_witness', array('id'), array(

--- a/mod/ojt/backup/moodle2/restore_ojt_stepslib.php
+++ b/mod/ojt/backup/moodle2/restore_ojt_stepslib.php
@@ -117,6 +117,11 @@ class restore_ojt_activity_structure_step extends restore_activity_structure_ste
         $data->topicid = $this->get_mappingid('ojt_topic', $data->topicid);
         $data->topicitemid = $this->get_mappingid('ojt_topic_item', $data->topicitemid);
         $data->modifiedby = $this->get_mappingid('user', $data->userid);
+        //Legacy backups may still store the complcomment as "comment"
+        if(isset($data->comment)) {
+            $data->complcomment = $data->comment;
+            unset($data->comment);
+        }
 
         // Add ojt topic.
         $newitemid = $DB->insert_record('ojt_completion', $data);


### PR DESCRIPTION
The field was renamed from comment as it is a reserved word, it also
adds some code to check if a restored completion uses the old name and set it to
the new name