### PR TITLE
Change user content restriction to work with job assignments

### DIFF
--- a/rb_sources/rb_source_ojt_completion.php
+++ b/rb_sources/rb_source_ojt_completion.php
@@ -318,13 +318,7 @@ class rb_source_ojt_completion extends rb_base_source {
             new rb_content_option(
                 'user',
                 get_string('user', 'rb_source_ojt_completion'),
-                array(
-                    'userid' => 'base.userid',
-                    'managerid' => 'position_assignment.managerid',
-                    'managerpath' => 'position_assignment.managerpath',
-                    'postype' => 'position_assignment.type',
-                ),
-                'position_assignment'
+                'userid' => 'base.userid'
             ),
             new rb_content_option(
                 'ojt_completion_type',


### PR DESCRIPTION
The position assignment table no longer exists, and the content
restriction no longer needs the match fields passed through, it
uses the job assignment tables instead