### PR TITLE
Force download of files attached to an OJT

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -261,7 +261,7 @@ class mod_ojt_renderer extends plugin_renderer_base {
 
         foreach ($files as $file) {
             $filename = $file->get_filename();
-            $url = moodle_url::make_pluginfile_url($file->get_contextid(), $file->get_component(), $file->get_filearea(), $file->get_itemid(), $file->get_filepath(), $file->get_filename());
+            $url = moodle_url::make_pluginfile_url($file->get_contextid(), $file->get_component(), $file->get_filearea(), $file->get_itemid(), $file->get_filepath(), $file->get_filename(), true);
             $out[] = html_writer::link($url, $filename);
         }
         $br = html_writer::empty_tag('br');


### PR DESCRIPTION
Thanks to Dan for the recommendation of the fix and Sergey for reporting. This forces downloading the files rather than viewing them thus moving the XSS issue from the site into the browsers sandbox/wherever they may open it.
Fixes #23 