### PR TITLE
Restrict manager to see direct reports only

### DIFF
--- a/evaluate.php
+++ b/evaluate.php
@@ -64,8 +64,10 @@ $userojt = ojt_get_user_ojt($ojt->id, $userid);
 $PAGE->set_url('/mod/ojt/evaluate.php', array('cmid' => $cm->id, 'userid' => $userid));
 $PAGE->set_title(format_string($ojt->name));
 $PAGE->set_heading(format_string($ojt->name).' - '.get_string('evaluate', 'ojt'));
-if (has_capability('mod/ojt:evaluate', $modcontext) || has_capability('mod/ojt:signoff', $modcontext)) {
+if (has_capability('mod/ojt:evaluate', $modcontext)) {
     $PAGE->navbar->add(get_string('evaluatestudents', 'ojt'), new moodle_url('/mod/ojt/report.php', array('cmid' => $cm->id)));
+} else if (has_capability('mod/ojt:signoff', $modcontext)) {
+    $PAGE->navbar->add(get_string('evaluatestudents', 'ojt'), new moodle_url('/mod/ojt/reportsignoff.php', array('cmid' => $cm->id)));
 }
 $PAGE->navbar->add(fullname($user));
 

--- a/lib.php
+++ b/lib.php
@@ -494,8 +494,11 @@ function ojt_pluginfile($course, $cm, $context, $filearea, array $args, $forcedo
  */
 function ojt_extend_navigation(navigation_node $navref, stdClass $course, stdClass $module, cm_info $cm) {
     $context = context_module::instance($cm->id);
-    if (has_capability('mod/ojt:evaluate', $context) || has_capability('mod/ojt:signoff', $context)) {
+    if (has_capability('mod/ojt:evaluate', $context)) {
         $link = new moodle_url('/mod/ojt/report.php', array('cmid' => $cm->id));
+        $node = $navref->add(get_string('evaluatestudents', 'ojt'), $link, navigation_node::TYPE_SETTING);
+    } else if (has_capability('mod/ojt:signoff', $context)) {
+        $link = new moodle_url('/mod/ojt/reportsignoff.php', array('cmid' => $cm->id));
         $node = $navref->add(get_string('evaluatestudents', 'ojt'), $link, navigation_node::TYPE_SETTING);
     }
 
@@ -514,9 +517,13 @@ function ojt_extend_settings_navigation(settings_navigation $settingsnav, naviga
     global $PAGE;
 
     if (has_capability('mod/ojt:evaluate', $PAGE->cm->context) || has_capability('mod/ojt:signoff', $PAGE->cm->context)) {
-        $link = new moodle_url('/mod/ojt/report.php', array('cmid' => $PAGE->cm->id));
+        if (has_capability('mod/ojt:evaluate', $PAGE->cm->context)) {
+            $link = new moodle_url('/mod/ojt/report.php', array('cmid' => $PAGE->cm->id));
+        } else if (has_capability('mod/ojt:signoff', $PAGE->cm->context)) {
+            $link = new moodle_url('/mod/ojt/reportsignoff.php', array('cmid' => $PAGE->cm->id));
+        }
         $node = navigation_node::create(get_string('evaluatestudents', 'ojt'),
-                new moodle_url('/mod/ojt/report.php', array('cmid' => $PAGE->cm->id)),
+                $link,
                 navigation_node::TYPE_SETTING, null, 'mod_ojt_evaluate',
                 new pix_icon('i/valid', ''));
         $ojtnode->add_node($node);

--- a/rb_sources/lang/en/rb_source_ojt_completion.php
+++ b/rb_sources/lang/en/rb_source_ojt_completion.php
@@ -4,6 +4,7 @@ $string['ojt'] = 'OJT';
 $string['ojtcompletion'] = 'OJT Completion';
 $string['ojtcompletiontype'] = 'OJT completion type';
 $string['ojtevaluation'] = 'OJT Evaluation';
+$string['ojtevaluationsignoff'] = 'OJT Evaluation Sign-off';
 $string['ojtname'] = 'OJT name';
 $string['completionstatus'] = 'Completion status';
 $string['completiontypeenable'] = 'Show records based on ojt completion type';

--- a/rb_sources/rb_ojt_evaluation_signoff_embedded.php
+++ b/rb_sources/rb_ojt_evaluation_signoff_embedded.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * Copyright (C) 2015 onwards Catalyst IT
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author  Eugene Venter <eugene@catalyst.net.nz>
+ * @package mod_ojt
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+ 
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+use totara_reportbuilder\rb\content\base;
+
+# Include the ojt rb source, to ensure all default settings get created upon report creation
+require_once($CFG->dirroot.'/mod/ojt/rb_sources/rb_source_ojt_completion.php');
+require_once($CFG->dirroot.'/mod/ojt/lib.php');
+class rb_ojt_evaluation_signoff_embedded extends rb_base_embedded {
+
+    public $url, $source, $fullname, $filters, $columns;
+    public $contentmode, $contentsettings, $embeddedparams;
+    public $hidden, $accessmode, $accesssettings, $shortname;
+    public $defaultsortcolumn, $defaultsortorder;
+
+    public function __construct($data) {
+        $ojtid = array_key_exists('ojtid', $data) ? $data['ojtid'] : null;
+
+        $url = new moodle_url('/mod/ojt/reportsignoff.php', $data);
+        $this->url = $url->out_as_local_url();
+        $this->source = 'ojt_completion';
+        $this->defaultsortcolumn = 'user_namelink';
+        $this->shortname = 'ojt_evaluation_signoff';
+        $this->fullname = get_string('ojtevaluationsignoff', 'rb_source_ojt_completion');
+        $this->columns = array(
+            array(
+                'type' => 'user',
+                'value' => 'namelink',
+                'heading' => get_string('name', 'rb_source_user'),
+            ),
+            array(
+                'type' => 'base',
+                'value' => 'status',
+                'heading' => get_string('status', 'rb_source_ojt_completion'),
+            ),
+            array(
+                'type' => 'ojt',
+                'value' => 'evaluatelink',
+                'heading' => ' ',
+            ),
+        );
+
+        // no filters
+        $this->filters = array(
+            array(
+                'type' => 'user',
+                'value' => 'fullname',
+                'advanced' => 0,
+            ),
+            array(
+                'type' => 'base',
+                'value' => 'status',
+                'advanced' => 0,
+            ),
+        );
+
+        $this->contentmode = REPORT_BUILDER_CONTENT_MODE_ALL;
+        $this->contentsettings = array(
+            'ojt_completion_type' => array(
+                'enable' => 1,
+                'completiontype' => OJT_CTYPE_OJT
+            )
+        );
+
+        // only show non-deleted users
+        $this->embeddedparams = array();
+        if (!empty($ojtid)) {
+            $this->embeddedparams['ojtid'] = $ojtid;
+        }
+
+        parent::__construct($data);
+    }
+
+    /**
+     * Check if the user is capable of accessing this report.
+     * We use $reportfor instead of $USER->id and $report->get_param_value() instead of getting params
+     * some other way so that the embedded report will be compatible with the scheduler (in the future).
+     *
+     * @param int $reportfor userid of the user that this report is being generated for
+     * @param reportbuilder $report the report object - can use get_param_value to get params
+     * @return boolean true if the user can access this report
+     */
+    public function is_capable($reportfor, $report) {
+        return true;
+    }
+}

--- a/reportsignoff.php
+++ b/reportsignoff.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * Copyright (C) 2015 onwards Catalyst IT
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author  Eugene Venter <eugene@catalyst.net.nz>
+ * @package mod_ojt
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Prints a particular instance of ojt
+ */
+
+require_once(dirname(dirname(dirname(__FILE__))).'/config.php');
+require_once($CFG->dirroot.'/mod/ojt/lib.php');
+require_once($CFG->dirroot.'/totara/reportbuilder/lib.php');
+
+$cmid = optional_param('cmid', 0, PARAM_INT); // Course_module ID
+$ojtid  = optional_param('bid', 0, PARAM_INT);  // ... ojt instance ID - it should be named as the first character of the module.
+$format = optional_param('format', '', PARAM_TEXT);
+$sid = optional_param('sid', '0', PARAM_INT);
+$debug = optional_param('debug', 0, PARAM_INT);
+
+if ($cmid) {
+    $cm         = get_coursemodule_from_id('ojt', $cmid, 0, false, MUST_EXIST);
+    $course     = $DB->get_record('course', array('id' => $cm->course), '*', MUST_EXIST);
+    $ojt  = $DB->get_record('ojt', array('id' => $cm->instance), '*', MUST_EXIST);
+} else if ($ojtid) {
+    $ojt  = $DB->get_record('ojt', array('id' => $ojtid), '*', MUST_EXIST);
+    $course     = $DB->get_record('course', array('id' => $ojt->course), '*', MUST_EXIST);
+    $cm         = get_coursemodule_from_instance('ojt', $ojt->id, $course->id, false, MUST_EXIST);
+} else {
+    print_error('You must specify a course_module ID or an instance ID');
+}
+
+require_login($course, true, $cm);
+
+$modcontext = context_module::instance($cm->id);
+if (!(has_capability('mod/ojt:evaluate', $modcontext) || has_capability('mod/ojt:signoff', $modcontext))) {
+    print_error('accessdenied', 'ojt');
+}
+
+$config = new rb_config();
+$config->set_sid($sid)
+    ->set_embeddata(array('ojtid' => $ojt->id));
+
+if (!$report = reportbuilder::create_embedded('ojt_evaluation_signoff', $config)) {
+    print_error('error:couldnotgenerateembeddedreport', 'totara_reportbuilder');
+}
+
+$PAGE->set_url('/mod/ojt/reportsignoff.php', array('cmid' => $cm->id));
+$PAGE->set_title(format_string($ojt->name));
+$headingstr = format_string($ojt->name).' - '.get_string('evaluate', 'ojt');
+$PAGE->set_heading($headingstr);
+
+
+$renderer = $PAGE->get_renderer('totara_reportbuilder');
+
+if ($format != '') {
+    $report->export_data($format);
+    die;
+}
+
+$report->include_js();
+
+echo $OUTPUT->header();
+
+echo $OUTPUT->heading($headingstr);
+
+// Standard report stuff.
+echo $OUTPUT->container_start('', 'ojt_evaluation');
+
+if ($debug) {
+    $report->debug($debug);
+}
+echo $renderer->print_description($report->description, $report->_id);
+
+$report->display_search();
+$report->display_sidebar_search();
+
+$report->display_table();
+
+// Export button.
+$renderer->export_select($report, $sid);
+
+echo $OUTPUT->container_end();
+
+echo $OUTPUT->footer();
+

--- a/view.php
+++ b/view.php
@@ -94,12 +94,18 @@ if ($canmanage) {
 }
 
 // "Evaluate students" button
-if (($canevaluate || $cansignoff)) {
+if ($canevaluate) {
+    $link = new moodle_url('/mod/ojt/report.php', array('cmid' => $cm->id));
+} else if ($cansignoff) {
+    $link = new moodle_url('/mod/ojt/reportsignoff.php', array('cmid' => $cm->id));
+}
+if (isset($link)) {
     echo html_writer::start_tag('div', array('class' => 'mod-ojt-evalstudents-btn'));
-    echo $OUTPUT->single_button(new moodle_url('/mod/ojt/report.php', array('cmid' => $cm->id)),
+    echo $OUTPUT->single_button($link,
         get_string('evaluatestudents', 'ojt'), 'get');
     echo html_writer::end_tag('div');
 }
+
 
 $userojt = ojt_get_user_ojt($ojt->id, $USER->id);
 


### PR DESCRIPTION
Hi,
This change will add the ability to restrict managers to see direct reports only.
This stems from privacy concerns and making the user experience better.

**Background setup:** 
- Go to Admin -> Permissions -> Capability overview
-- Add capability mod/ojt:signoff to the role 'Staff manager'  
-- Add capability mod/ojt:evaluate to the  role 'Trainer'
- Go to Admin -> users
-- Create a user with username: manager and add the role 'Staff manager'
-- Create a user with username: learner
--- Click 'Add job assignment' and click 'Choose Manager'. Select user 'manager'
-- Create a user with username: trainer
- Go to Admin -> Courses and categories
- Click 'Create new course' 
-- Go to the course and click 'Participants' and enrol the above three users in it
-- Add role 'Trainer' to user 'trainer.
-- Add an OJT activity and Enable setting 'Manager sign-off'  
- Go to Reports -> Manage embedded reports and search for 'OJT Evaluation Sign-off' report
- Go to Content -> Show records based on user -> Records for user's direct reports for any of the user's job assignments

**Before the change**
- Login as user manager and go to OJT activity and click 'Evaluate students'. You will see all the users enrolled in the course. 
- Login as user trainer and go to OJT activity and click 'Evaluate students'. You will see all the users enrolled in the course. 

**After the change**
- Login as user manager and go to OJT activity and click 'Evaluate students'. You will see only the users that report to the manager (direct reports) 
- Login as user trainer and go to OJT activity and click 'Evaluate students'. You will see all the users enrolled in the course. 

Regards,
Sumaiya