### PR TITLE
Add support for "user must view activity" completion

### DIFF
--- a/evaluate.php
+++ b/evaluate.php
@@ -57,6 +57,10 @@ if (!($canevaluate || $cansignoff || $canwitness)) {
     print_error('accessdenied', 'ojt');
 }
 
+// Mark viewed by user (if required).
+$completion = new completion_info($course);
+$completion->set_module_viewed($cm);
+
 $userojt = ojt_get_user_ojt($ojt->id, $userid);
 
 // Print the page header.
@@ -90,8 +94,6 @@ $jsmodule = array(
     'requires' => array('json')
 );
 $PAGE->requires->js_init_call('M.mod_ojt_expandcollapse.init', array(), false, $jsmodule);
-
-
 
 // Output starts here.
 echo $OUTPUT->header();

--- a/view.php
+++ b/view.php
@@ -81,6 +81,9 @@ if ($canevalself && !($canevaluate || $cansignoff)) {
         array('userid' => $USER->id, 'bid' => $ojt->id)));
 }
 
+// Mark viewed by user (if required).
+$completion = new completion_info($course);
+$completion->set_module_viewed($cm);
 
 // Output starts here.
 echo $OUTPUT->header();


### PR DESCRIPTION
In #50, I assumed this plugin had support for module viewing (i.e., in activity completion, adding "user must view the module"), because it had a call to `$completion->set_module_viewed_reset()`. So, I added `FEATURE_COMPLETION_TRACKS_VIEWS` to `ojt_supports()`.

But, it turns out I was wrong. :-P The plugin did not yet support this. It had no code to actually mark that a user had viewed the module. (So it didn't need to be calling `set_module_viewed_reset()`. Possibly this code was there because it was copied from another plugin.)

So that means that, since I added the flag, the completion settings for an OJT activity have a section for "User must view the module", but if it's enabled, then a learner can never complete the activity because it will never be marked as viewed.

I considered removing the `FEATURE_COMPLETION_TRACKS_VIEWS` flag, but then I would also need to write an upgrade script to reconfigure any activities out there that have already been created and set to "User must view the module". It seemed simpler just to add support for module view tracking.