### PR TITLE
Check for sesskey when deleting a topic. Fixes #56

### DIFF
--- a/topic.php
+++ b/topic.php
@@ -52,6 +52,7 @@ if ($delete) {
         die();
     }
 
+    require_sesskey();
     ojt_delete_topic($topicid);
     $redirecturl = new moodle_url('/mod/ojt/manage.php', array('cmid' => $cm->id));
     redirect($redirecturl, get_string('topicdeleted', 'ojt'));


### PR DESCRIPTION
To test:

1. Create a new OJT instance.
2. Open the OJT instance and click "Edit topics".
3. Create a new topic and return to the "Edit topics" screen.
4. Click the Delete (X) icon next to the topic.
5. When the confirmation screen is shown, instead of clicking confirm, add `&confirm=1` to the end of the page's URL and press enter.
6. **Confirm** that you see an error. 
   * **Before fix**: The topic was deleted.